### PR TITLE
New Menu Handling

### DIFF
--- a/include/start_screen.hpp
+++ b/include/start_screen.hpp
@@ -1,15 +1,19 @@
 #ifndef START_SCREEN_HPP
 #define START_SCREEN_HPP
-enum Screens
+
+
+enum screens
 {
-    Start,
-    Unlink,
-    Backup,
-    Swap,
-    Overwrite
+    START_SCREEN,
+    UNLINK_SCREEN,
+    BACKUP_SCREEN,
+    SWAP_SCREEN,
+    OVERWRITE_SCREEN
 };
 
-extern Screens CurrentScreen;
+
+extern screens current_screen;
+
 
 void draw_start_screen(int selected_menu_item);
 void process_start_screen();

--- a/include/start_screen.hpp
+++ b/include/start_screen.hpp
@@ -1,9 +1,18 @@
 #ifndef START_SCREEN_HPP
 #define START_SCREEN_HPP
+enum Screens
+{
+    Start,
+    Unlink,
+    Backup,
+    Swap,
+    Overwrite
+};
 
+extern Screens CurrentScreen;
 
 void draw_start_screen(int selected_menu_item);
 void process_start_screen();
-
+void process_screens();
 
 #endif

--- a/source/backup.cpp
+++ b/source/backup.cpp
@@ -128,17 +128,23 @@ backup_account()
 
     // Check if the backup file exists.
     std::ifstream ifile(backup_path);
+
+    CurrentScreen = Overwrite;
+
     if (ifile) {
         backup_confirm = false;
+        bool selected = false;
 
-        while (WHBProcIsRunning()) {
+        while (!selected) {
             draw_overwrite_menu(backup_path.c_str());
             int button = read_input();
 
             if (button & VPAD_BUTTON_A) {
                 backup_confirm = true;
+                selected = true;
                 break;
             } else if (button & VPAD_BUTTON_B) {
+                selected = true;
                 break;
             }
         }
@@ -146,13 +152,21 @@ backup_account()
         backup_confirm = true;
     }
 
+    CurrentScreen = Backup;
+
     // Write the backup file.
     if (backup_confirm) {
         if (write_backup(account, backup_path, buffer))
+        {
             handle_cleanup(account, NULL, buffer, false);
+            CurrentScreen = Start;
+        }
         return true;
     }
 
     handle_cleanup(account, NULL, buffer, !backup_confirm);
+    CurrentScreen = Start;
     return true;
+
+
 }

--- a/source/backup.cpp
+++ b/source/backup.cpp
@@ -129,7 +129,7 @@ backup_account()
     // Check if the backup file exists.
     std::ifstream ifile(backup_path);
 
-    CurrentScreen = Overwrite;
+    current_screen = OVERWRITE_SCREEN;
 
     if (ifile) {
         backup_confirm = false;
@@ -152,20 +152,20 @@ backup_account()
         backup_confirm = true;
     }
 
-    CurrentScreen = Backup;
+    current_screen = BACKUP_SCREEN;
 
     // Write the backup file.
     if (backup_confirm) {
         if (write_backup(account, backup_path, buffer))
         {
             handle_cleanup(account, NULL, buffer, false);
-            CurrentScreen = Start;
+            current_screen = START_SCREEN;
         }
         return true;
     }
 
     handle_cleanup(account, NULL, buffer, !backup_confirm);
-    CurrentScreen = Start;
+    current_screen = START_SCREEN;
     return true;
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -172,7 +172,7 @@ main()
 
     while (WHBProcIsRunning()) {
         if (!error_occurred)
-            process_start_screen();
+            process_screens();
     }
 
     deinitialize();

--- a/source/start_screen.cpp
+++ b/source/start_screen.cpp
@@ -30,7 +30,7 @@
 
 int selected_option = 0;
 const int NUM_OPTIONS = 4;
-
+Screens CurrentScreen = Start;
 
 bool
 swap_account_action(const char* account_backup, const char* account_type)
@@ -40,6 +40,9 @@ swap_account_action(const char* account_backup, const char* account_type)
         SYSLaunchMenu();
         return true;
     }
+
+    CurrentScreen = Start;
+
     return false;
 }
 
@@ -47,17 +50,19 @@ swap_account_action(const char* account_backup, const char* account_type)
 bool
 backup_account_action()
 {
-    while (WHBProcIsRunning()) {
         OSEnableHomeButtonMenu(0);
         draw_backup_menu();
         int button = read_input();
 
         if (button & VPAD_BUTTON_A) {
             backup_account();
+            CurrentScreen = Start;
             return true;
         } else if (button & VPAD_BUTTON_B)
+        {
+            CurrentScreen = Start;
             return true;
-    }
+        }
     return false;
 }
 
@@ -66,18 +71,20 @@ bool
 unlink_account_action()
 {
     OSEnableHomeButtonMenu(0);
-    while (WHBProcIsRunning()) {
-        draw_unlink_menu();
-        int button = read_input();
+    draw_unlink_menu();
+    int button = read_input();
 
-        if (button & VPAD_BUTTON_A) {
-            if (unlink_account()) {
-                OSForceFullRelaunch();
-                SYSLaunchMenu();
-                return true;
-            }
-        } else if (button & VPAD_BUTTON_B)
+    if (button & VPAD_BUTTON_A) {
+        if (unlink_account()) {
+            OSForceFullRelaunch();
+            SYSLaunchMenu();
             return true;
+        }
+    }
+    else if (button & VPAD_BUTTON_B)
+    {
+        CurrentScreen = Start;
+        return true;
     }
     return false;
 }
@@ -147,19 +154,51 @@ process_start_screen()
     } else if (button & VPAD_BUTTON_A) {
         switch (selected_option) {
             case 0:
-                swap_account_action(NNID_BACKUP.c_str(), "Nintendo");
+                CurrentScreen = Swap;
+                //swap_account_action(NNID_BACKUP.c_str(), "Nintendo");
                 break;
             case 1:
-                swap_account_action(PNID_BACKUP.c_str(), "Pretendo");
+                CurrentScreen = Swap;
+                //swap_account_action(PNID_BACKUP.c_str(), "Pretendo");
                 break;
             case 2:
-                backup_account_action();
+                CurrentScreen = Backup;
+                //backup_account_action();
                 break;
             case 3:
-                unlink_account_action();
+                CurrentScreen = Unlink;
+                //unlink_account_action();
                 break;
         }
     } else if (button & VPAD_BUTTON_SYNC) {
         play_easter_egg();
+    }
+}
+
+void process_screens()
+{
+    switch(CurrentScreen)
+    {
+        case Start:
+            process_start_screen();
+            break;
+        case Unlink:
+            unlink_account_action();
+            break;
+        case Swap:
+            if(selected_option == 0)
+            {
+                swap_account_action(NNID_BACKUP.c_str(), "Nintendo");
+            }
+            else
+            {
+                swap_account_action(PNID_BACKUP.c_str(), "Pretendo");
+            }
+            break;
+        case Backup:
+            backup_account_action();
+            break;
+        case Overwrite:
+            break;
     }
 }

--- a/source/start_screen.cpp
+++ b/source/start_screen.cpp
@@ -30,7 +30,7 @@
 
 int selected_option = 0;
 const int NUM_OPTIONS = 4;
-Screens CurrentScreen = Start;
+screens current_screen = START_SCREEN;
 
 bool
 swap_account_action(const char* account_backup, const char* account_type)
@@ -41,7 +41,7 @@ swap_account_action(const char* account_backup, const char* account_type)
         return true;
     }
 
-    CurrentScreen = Start;
+    current_screen = START_SCREEN;
 
     return false;
 }
@@ -56,11 +56,11 @@ backup_account_action()
 
         if (button & VPAD_BUTTON_A) {
             backup_account();
-            CurrentScreen = Start;
+            current_screen = START_SCREEN;
             return true;
         } else if (button & VPAD_BUTTON_B)
         {
-            CurrentScreen = Start;
+            current_screen = START_SCREEN;
             return true;
         }
     return false;
@@ -83,7 +83,7 @@ unlink_account_action()
     }
     else if (button & VPAD_BUTTON_B)
     {
-        CurrentScreen = Start;
+        current_screen = START_SCREEN;
         return true;
     }
     return false;
@@ -154,19 +154,19 @@ process_start_screen()
     } else if (button & VPAD_BUTTON_A) {
         switch (selected_option) {
             case 0:
-                CurrentScreen = Swap;
+                current_screen = SWAP_SCREEN;
                 //swap_account_action(NNID_BACKUP.c_str(), "Nintendo");
                 break;
             case 1:
-                CurrentScreen = Swap;
+                current_screen = SWAP_SCREEN;
                 //swap_account_action(PNID_BACKUP.c_str(), "Pretendo");
                 break;
             case 2:
-                CurrentScreen = Backup;
+                current_screen = BACKUP_SCREEN;
                 //backup_account_action();
                 break;
             case 3:
-                CurrentScreen = Unlink;
+                current_screen = UNLINK_SCREEN;
                 //unlink_account_action();
                 break;
         }
@@ -177,28 +177,24 @@ process_start_screen()
 
 void process_screens()
 {
-    switch(CurrentScreen)
+    switch(current_screen)
     {
-        case Start:
+        case START_SCREEN:
             process_start_screen();
             break;
-        case Unlink:
+        case UNLINK_SCREEN:
             unlink_account_action();
             break;
-        case Swap:
+        case SWAP_SCREEN:
             if(selected_option == 0)
-            {
                 swap_account_action(NNID_BACKUP.c_str(), "Nintendo");
-            }
             else
-            {
                 swap_account_action(PNID_BACKUP.c_str(), "Pretendo");
-            }
             break;
-        case Backup:
+        case BACKUP_SCREEN:
             backup_account_action();
             break;
-        case Overwrite:
+        case OVERWRITE_SCREEN:
             break;
     }
 }


### PR DESCRIPTION
You already know the drill @Nightkingale , but for others reading this pull request:

This basically changes how the Menus are drawn / handled. We only have one WHBProcIsRunning() While-Loop which is called in the Main function in main.cpp.

This has the benefit, that if one forgets to close a secondary WHBProcIsRunning() Loop, that this will not cause the WiiU to freeze on exit of the App. 

This also fixes a Bug, when pushing a new WUHB or RPX using wiiload while having a submenu open. The Bug was caused, because there were two WHBProcIsRunning() Loops open, but only one was getting closed.

I added the already compiled WUHB, RPX and ELF file for testing.
[Wii_U_Account_Swap.zip](https://github.com/Nightkingale/Wii-U-Account-Swap/files/15343524/Wii_U_Account_Swap.zip)
